### PR TITLE
Update task names to be more descriptive in the example playbooks

### DIFF
--- a/playbooks/demo.yml
+++ b/playbooks/demo.yml
@@ -4,7 +4,7 @@
   vars_files:
     - ./vars/config.yml
   tasks:
-  - name: "Run activation module - Showcase no changes."
+  - name: "Activate changes on site - Showcase no changes."
     activation:
       server_url: "{{ server_url }}"
       site: "{{ site }}"
@@ -28,7 +28,7 @@
     run_once: 'yes'
     loop: "{{ checkmk_folders }}"
 
-  - name: "Create hosts."
+  - name: "Create host."
     host:
       server_url: "{{ server_url }}"
       site: "{{ site }}"
@@ -42,7 +42,7 @@
       state: "present"
     delegate_to: localhost
 
-  - name: "Discover hosts."
+  - name: "Discover services on host."
     discovery:
       server_url: "{{ server_url }}"
       site: "{{ site }}"
@@ -58,7 +58,7 @@
         "Feel free to review the changes in your Checkmk site: {{ site }}."
         "Press <Enter> to continue."
 
-  - name: "Run activation module - Showcase creation of hosts and folders."
+  - name: "Activate changes on site - Showcase creation of hosts and folders."
     activation:
       server_url: "{{ server_url }}"
       site: "{{ site }}"
@@ -101,7 +101,7 @@
         "Feel free to review the changes in your Checkmk site: {{ site }}."
         "Press <Enter> to continue."
 
-  - name: "Run activation module - Showcase changes to existing objects."
+  - name: "Activate changes on site - Showcase changes to existing objects."
     activation:
       server_url: "{{ server_url }}"
       site: "{{ site }}"
@@ -112,7 +112,7 @@
     delegate_to: localhost
     run_once: 'true'
 
-  - name: "Delete Hosts."
+  - name: "Delete Host."
     host:
       server_url: "{{ server_url }}"
       site: "{{ site }}"
@@ -137,7 +137,7 @@
     run_once: 'yes'
     loop: "{{ checkmk_folders }}"
 
-  - name: "Run activation module - 5."
+  - name: "Activate changes on site - Showcase host and folders were deleted"
     activation:
       server_url: "{{ server_url }}"
       site: "{{ site }}"

--- a/playbooks/test-full.yml
+++ b/playbooks/test-full.yml
@@ -9,7 +9,7 @@
   vars_files:
     - ./vars/config.yml
   tasks:
-  - name: "Run activation module - 1."
+  - name: "Activate changes on site - 1."
     activation:
       server_url: "{{ server_url }}"
       site: "{{ site }}"
@@ -34,7 +34,7 @@
     run_once: 'yes'
     loop: "{{ checkmk_folders }}"
 
-  - name: "Create hosts."
+  - name: "Create host."
     host:
       server_url: "{{ server_url }}"
       site: "{{ site }}"
@@ -48,7 +48,7 @@
       state: "present"
     delegate_to: localhost
 
-  - name: "Discover hosts."
+  - name: "Discover services on host."
     discovery:
       server_url: "{{ server_url }}"
       site: "{{ site }}"
@@ -60,7 +60,7 @@
       state: "refresh"
     delegate_to: localhost
 
-  - name: "Run activation module - 2."
+  - name: "Activate changes on site - 2."
     activation:
       server_url: "{{ server_url }}"
       site: "{{ site }}"
@@ -87,7 +87,7 @@
       state: "present"
     delegate_to: localhost
 
-  - name: "Run activation module - 3."
+  - name: "Activate changes on site - 3."
     activation:
       server_url: "{{ server_url }}"
       site: "{{ site }}"
@@ -110,7 +110,7 @@
       state: "present"
     delegate_to: localhost
 
-  - name: "Run activation module - 4."
+  - name: "Activate changes on site - 4."
     activation:
       server_url: "{{ server_url }}"
       site: "{{ site }}"
@@ -122,7 +122,7 @@
     delegate_to: localhost
     run_once: 'true'
 
-  - name: "Delete Hosts."
+  - name: "Delete Host."
     host:
       server_url: "{{ server_url }}"
       site: "{{ site }}"
@@ -146,7 +146,7 @@
     run_once: 'yes'
     loop: "{{ checkmk_folders }}"
 
-  - name: "Run activation module - 5."
+  - name: "Activate changes on site - 5."
     activation:
       server_url: "{{ server_url }}"
       site: "{{ site }}"

--- a/playbooks/test-user.yml
+++ b/playbooks/test-user.yml
@@ -5,7 +5,7 @@
     - ./vars/config.yml
     - ./vars/users.yml
   tasks:
-  - name: "Run activation module - 1."
+  - name: "Activate changes on site - 1."
     activation:
       server_url: "{{ server_url }}"
       site: "{{ site }}"
@@ -36,7 +36,7 @@
     run_once: 'yes'
     loop: "{{ checkmk_users }}"
 
-  - name: "Run activation module - 2."
+  - name: "Activate changes on site - 2."
     activation:
       server_url: "{{ server_url }}"
       site: "{{ site }}"
@@ -65,7 +65,7 @@
     run_once: 'yes'
     loop: "{{ checkmk_users }}"
 
-  - name: "Run activation module - 3."
+  - name: "Activate changes on site - 3."
     activation:
       server_url: "{{ server_url }}"
       site: "{{ site }}"
@@ -90,7 +90,7 @@
     run_once: 'yes'
     loop: "{{ checkmk_users }}"
 
-  - name: "Run activation module - 4."
+  - name: "Activate changes on site - 4."
     activation:
       server_url: "{{ server_url }}"
       site: "{{ site }}"


### PR DESCRIPTION
This PR changes the name of a few tasks in the example playbooks to be more descriptive.
In my opinion the current names don't really describe what the playbook is doing, making understanding this collection more complicated.
In particular the title "Run activation module" doesn't describe at all what it's doing, so I've changed it here to "Activate changes on site". 
The discovery example just has a wrong name, the name says "Discover hosts" when that's not what it's doing, it's discovering services on an existing host.
I also changed the "Create hosts" to "create host" since it's just adding a single host here, not multiple.