### PR TITLE
Add RHEL/CentOS 7&8 Support to the server role

### DIFF
--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -2,6 +2,10 @@
 checkmk_server_server_stable_os:
   - Debian 11
   - Ubuntu 20
+  - CentOS 7
+  - CentOS 8
+  - RHEL 7
+  - RHEL 8
 
 checkmk_server_edition: cre
 checkmk_server_version: 2.1.0p1

--- a/roles/server/tasks/RedHat.yml
+++ b/roles/server/tasks/RedHat.yml
@@ -1,0 +1,41 @@
+---
+- name: "Install libsemanage-python."
+  become: 'yes'
+  ansible.builtin.shell: dnf config-manager --set-enabled powertools
+  when: ansible_distribution_major_version == "8"
+
+- name: "Install Checkmk Server."
+  become: 'yes'
+  ansible.builtin.yum:
+    name: "/tmp/{{ checkmk_server_setup_file }}"
+    state: present
+    disable_gpg_check: '{{ not checkmk_server_verify_setup | bool }}'
+
+- name: "Install libsemanage-python."
+  become: 'yes'
+  ansible.builtin.yum: 
+    name: libsemanage-python
+    state: installed
+  when: ansible_distribution_major_version == "7"
+
+- name: "Install libsemanage-python."
+  become: 'yes'
+  ansible.builtin.yum: 
+    name: python3-libsemanage
+    state: installed
+  when: ansible_distribution_major_version == "8"
+
+- name: "Enable httpd can network connect selinux boolean."
+  become: 'yes'
+  seboolean: 
+    name: httpd_can_network_connect 
+    state: yes 
+    persistent: yes
+
+- name: "Open port 80 for httpd."
+  become: 'yes'
+  ansible.posix.firewalld:
+    service: http
+    permanent: 'yes'
+    immediate: 'yes'
+    state: enabled

--- a/roles/server/tasks/RedHat.yml
+++ b/roles/server/tasks/RedHat.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Install libsemanage-python."
+- name: "Enable powertools repository."
   become: 'yes'
   ansible.builtin.shell: dnf config-manager --set-enabled powertools
   when: ansible_distribution_major_version == "8"
@@ -10,20 +10,6 @@
     name: "/tmp/{{ checkmk_server_setup_file }}"
     state: present
     disable_gpg_check: '{{ not checkmk_server_verify_setup | bool }}'
-
-- name: "Install libsemanage-python."
-  become: 'yes'
-  ansible.builtin.yum: 
-    name: libsemanage-python
-    state: installed
-  when: ansible_distribution_major_version == "7"
-
-- name: "Install libsemanage-python."
-  become: 'yes'
-  ansible.builtin.yum: 
-    name: python3-libsemanage
-    state: installed
-  when: ansible_distribution_major_version == "8"
 
 - name: "Enable httpd can network connect selinux boolean."
   become: 'yes'

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -32,20 +32,28 @@
     mode: 0640
   when: checkmk_server_verify_setup | bool
 
+- block:
+  - name: "Import Checkmk GPG Key."
+    ansible.builtin.command: "gpg --import /tmp/Check_MK-pubkey.gpg"
+    when: checkmk_server_verify_setup | bool
+
+  - name: "Verify Checkmk Setup."
+    ansible.builtin.command: dpkg-sig --verify "/tmp/{{ checkmk_server_setup_file }}"
+    register: checkmk_server_verify_state
+    changed_when: not checkmk_server_verify_state
+    failed_when: not checkmk_server_verify_state
+
+  - name: "Print Verification Output."
+    debug:
+      msg: "{{ checkmk_server_verify_state.stdout_lines }} "
+  when: checkmk_server_verify_setup | bool and ansible_os_family == "Debian"
+
 - name: "Import Checkmk GPG Key."
-  ansible.builtin.command: "gpg --import /tmp/Check_MK-pubkey.gpg"
-  when: checkmk_server_verify_setup | bool
-
-- name: "Verify Checkmk Setup."
-  ansible.builtin.command: dpkg-sig --verify "/tmp/{{ checkmk_server_setup_file }}"
-  register: checkmk_server_verify_state
-  changed_when: not checkmk_server_verify_state
-  failed_when: not checkmk_server_verify_state
-  when: checkmk_server_verify_setup | bool
-
-- name: "Print Verification Output."
-  ansible.builtin.debug:
-    msg: "{{ checkmk_server_verify_state.stdout_lines }} "
+  become: 'yes'
+  ansible.builtin.rpm_key:
+    key: "/tmp/Check_MK-pubkey.gpg"
+    state: present
+  when: checkmk_server_verify_setup | bool and ansible_os_family == "RedHat"
 
 - name: Include OS Family specific Playbook.
   ansible.builtin.include_tasks: "{{ ansible_os_family }}.yml"

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -9,6 +9,10 @@
 - name: "Include OS Family specific Variables."
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
 
+- name: "Include RHEL Version specific Variables."
+  ansible.builtin.include_vars: "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
+  when: ansible_os_family == "RedHat"
+
 - name: "Install Checkmk Prerequisites."
   become: true
   ansible.builtin.package:

--- a/roles/server/vars/RedHat-7.yml
+++ b/roles/server/vars/RedHat-7.yml
@@ -1,0 +1,2 @@
+---
+python_semanage_package: libsemanage-python

--- a/roles/server/vars/RedHat-8.yml
+++ b/roles/server/vars/RedHat-8.yml
@@ -1,0 +1,2 @@
+---
+python_semanage_package: python3-libsemanage

--- a/roles/server/vars/RedHat.yml
+++ b/roles/server/vars/RedHat.yml
@@ -1,0 +1,5 @@
+---
+checkmk_server_setup_file: "check-mk-{{ checkmk_server_edition_mapping[checkmk_server_edition] }}-{{ checkmk_server_version }}-el{{ ansible_distribution_major_version }}-38.x86_64.rpm"
+
+checkmk_server_prerequisites:
+  - epel-release

--- a/roles/server/vars/RedHat.yml
+++ b/roles/server/vars/RedHat.yml
@@ -3,3 +3,4 @@ checkmk_server_setup_file: "check-mk-{{ checkmk_server_edition_mapping[checkmk_s
 
 checkmk_server_prerequisites:
   - epel-release
+  - "{{ python_semanage_package }}"


### PR DESCRIPTION
This pull request adds tasks to install Checkmk on RHEL and CentOS 7 and 8.

I have tested these to install Checkmk 2.1.0p3 and managed services edition on CentOS 7 and CentOS Stream 8 on a clean VM with Vagrant. 

<details> <summary> server.yml used </summary> 

```yml
checkmk_server_download_url: 'https://download.checkmk.com/checkmk/2.1.0p3/check-mk-managed-2.1.0p3-el7-38.x86_64.rpm'
checkmk_server_download_user: redacted
checkmk_server_download_pass: redacted
checkmk_server_verify_setup: 'true'
checkmk_server_version: 2.1.0p3
checkmk_server_edition: cme
checkmk_server_sites:
  - name: server1
    version: "2.1.0p3"
    state: started
    admin_pw: redacted
```
</details>

## Pull request type
Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
The server role only supports Debian and Ubuntu, not RHEL and it's derivatives.

## What is the new behavior?
This adds the required variables to install Checkmk using this role on RHEL systems. It also sets the necessary SELinux booleans and firewalld changes.