### PR TITLE
Install xinetd when systemd <220

### DIFF
--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -6,3 +6,4 @@ checkmk_agent_server: localhost
 checkmk_agent_site: my_site
 checkmk_agent_update: 'false'
 checkmk_agent_tls: 'false'
+checmmk_agent_prep_legacy: 'true'

--- a/roles/agent/tasks/legacy.yml
+++ b/roles/agent/tasks/legacy.yml
@@ -1,0 +1,11 @@
+---
+- name: "Install xinetd"
+  ansible.builtin.package:
+    name: xinetd
+    state: present
+
+- name: "Enable xinetd"
+  ansible.builtin.service:
+    name: xinetd
+    state: started
+    enabled: true

--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -2,6 +2,14 @@
 - name: "Include Derivate specific Variables."
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
 
+- name: "Get RPM or APT package facts."
+  ansible.builtin.package_facts:
+    manager: "auto"
+
+- name: "Import Legacy agent tasks."
+  ansible.builtin.include_tasks: "legacy.yml"
+  when: ansible_facts.packages['systemd'][0]['version'] | regex_search('\d{3,}') | int < 220 and checmmk_agent_prep_legacy | bool
+
 - name: "Download Checkmk CRE Agent."
   ansible.builtin.get_url:
     url: "{{ checkmk_agent_agent.url.cre }}"


### PR DESCRIPTION
The new Checkmk 2.1 Linux agent requires Systemd version 220 or higher to function. If systemd is not version 220 or higher, the install script will instead deploy it for use with xinetd.

This PR adds a task to ensure xinetd is installed if the Systemd version is below 220. The agent installer will register with xinetd instead and use this to run the agent service.

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
If xinetd is not installed, this can result in the agent not working on older system. CentOS 7 has Systemd 219 so it is included in this.

## What is the new behavior?
Xinetd is installed and enabled on systems where the Systemd version is below 220. There is also a variable `checmmk_agent_prep_legacy` which is trrue by default. This can be set to false if you don't want the role to do this, for example if you want to use your own system for this.
