### PR TITLE
Add check for if firewalld is running

### DIFF
--- a/roles/server/tasks/RedHat.yml
+++ b/roles/server/tasks/RedHat.yml
@@ -18,6 +18,10 @@
     state: yes 
     persistent: yes
 
+- name: "Get service facts."
+  ansible.builtin.service_facts:
+  register: services_state
+
 - name: "Open port 80 for httpd."
   become: 'yes'
   ansible.posix.firewalld:
@@ -25,3 +29,4 @@
     permanent: 'yes'
     immediate: 'yes'
     state: enabled
+  when: services_state.ansible_facts.services['firewalld.service']['state'] == 'running'


### PR DESCRIPTION
This makes Ansible only open firewalld when firewalld is actually running.

## Pull request type


Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Play fails when firewalld is not running

Described in the comments of https://github.com/tribe29/ansible-collection-tribe29.checkmk/pull/64

## What is the new behavior?
A check checks if the firewalld service is running