### PR TITLE
Add option to add the host and discover services with the host and discovery modules

### DIFF
--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -4,5 +4,10 @@ checkmk_agent_edition: cre
 checkmk_agent_protocol: http
 checkmk_agent_server: localhost
 checkmk_agent_site: my_site
+checkmk_agent_add_host: 'false'
 checkmk_agent_update: 'false'
 checkmk_agent_tls: 'false'
+checkmk_agent_discover: 'false'
+checkmk_agent_delegate_api_calls: localhost
+checkmk_agent_host_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
+checkmk_agent_host_name: "{{ hostvars[inventory_hostname]['ansible_fqdn'] }}" 

--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -46,7 +46,7 @@
   register: checkmk_host_agent_tls_state
   when: (checkmk_agent_edition == "cee") and checkmk_agent_tls | bool
 
-- name: Discover services
+- name: "Discover services and labels on host."
   tribe29.checkmk.discovery:
     server_url: "{{ checkmk_agent_protocol }}://{{ checkmk_agent_server }}/"
     site: "{{ checkmk_agent_site }}"

--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -12,6 +12,22 @@
 - name: "Run OS Family specific Tasks."
   ansible.builtin.include_tasks: "{{ ansible_os_family }}.yml"
 
+- name: "Create host on server."
+  tribe29.checkmk.host:
+    server_url: "{{ checkmk_agent_protocol }}://{{ checkmk_agent_server }}/"
+    site: "{{ checkmk_agent_site }}"
+    automation_user: "{{ automation_user }}"
+    automation_secret: "{{ automation_secret }}"
+    folder: "{{ checkmk_agent_folder | default(omit) }}"
+    host_name: "{{ checkmk_agent_host_name }}"
+    attributes:
+      ipaddress: "{{ checkmk_agent_host_ip }}"
+      tag_agent: 'cmk-agent'
+  register: createResult
+  failed_when: createResult.failed is true and "The host is already part of the specified target folder" not in createResult.msg
+  delegate_to: "{{ checkmk_agent_delegate_api_calls }}"
+  when: checkmk_agent_add_host | bool
+
 - name: "Register Agent for automatic Upates."
   become: true
   ansible.builtin.shell: |
@@ -29,3 +45,14 @@
     -U {{ automation_user }} -P {{ automation_secret }} --trust-cert
   register: checkmk_host_agent_tls_state
   when: (checkmk_agent_edition == "cee") and checkmk_agent_tls | bool
+
+- name: Discover services
+  tribe29.checkmk.discovery:
+    server_url: "{{ checkmk_agent_protocol }}://{{ checkmk_agent_server }}/"
+    site: "{{ checkmk_agent_site }}"
+    automation_user: "{{ automation_user }}"
+    automation_secret: "{{ automation_secret }}"
+    host_name: "{{ checkmk_agent_host_name }}"
+    state: "fix_all"
+  delegate_to: "{{ checkmk_agent_delegate_api_calls }}"
+  when: checkmk_agent_discover | bool


### PR DESCRIPTION
Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
The role does not automatically register the machine as a host in Checkmk. If this is not done manually before hand this will also result in the TLS step failing. This adds a feature to automatically register it, this way an entire server with added hosts can be rolled out completely non-interactively. 

## What is the new behavior?
The `tribe29.checkmk.host` and `tribe.checkmk.discovery` modules are used to add and discover the host.
The new booleans `checkmk_agent_add_host` and `checkmk_agent_discover` determine whether the role should add the host to the Checkmk server and whether to discover services and labels on this host. Both variables default to false.

The `checkmk_agent_delegate_api_calls` variable is used to determine which host the API calls will be sent from, defaults to `localhost`, but if the server isn't reachable from here, you can set another host that can.

The `checkmk_agent_host_ip` is set to the Ansible default IPv4 address, but can be overwritten manually, same goes for the `checkmk_agent_host_name` but for the FQDN.

The `checkmk_agent_folder` can be used to put this host in a given folder, if not given it will be omitted. 