### PR TITLE
Increase HTTP timeout for discovery from 10 to 60 seconds

### DIFF
--- a/plugins/modules/discovery.py
+++ b/plugins/modules/discovery.py
@@ -136,7 +136,8 @@ def run_module():
     )
     url = base_url + api_endpoint
     response, info = fetch_url(
-        module, url, module.jsonify(params), headers=headers, method="POST"
+        module, url, module.jsonify(params), headers=headers, method="POST",
+        timeout=60
     )
     http_code = info["status"]
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!---
Please use the devel branch as the merge target!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, if people are using the branch directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Discovery for a SNMP host often won't finish within the 10 seconds HTTP timeout used by fetch_url, resulting in an error.

## What is the new behavior?
Set timeout to 60 seconds. 

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
