### PR TITLE
Disable leaking admin_pw to log in task "Destroy Sites"

### DIFF
--- a/roles/server/tasks/sites.yml
+++ b/roles/server/tasks/sites.yml
@@ -46,7 +46,7 @@
   args:
     executable: /bin/bash
     removes: "/omd/sites/{{ item.name }}"
-  # no_log: true
+  no_log: true
   loop: "{{ checkmk_server_sites }}"
   when: item.state == "absent"
   register: checkmk_server_sites_removed


### PR DESCRIPTION
This task should use no_log, as all other tasks already do.

<!--- Please provide a general summary of your changes in the title above -->

<!---
Please use the devel branch as the merge target!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, if people are using the branch directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
admin_pw is leaked to log if task is skipped.

## What is the new behavior?
Set no_log to disable logging from this task


## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
