### PR TITLE
[FEATURE] Don't hardcode host attributes

### DIFF
--- a/roles/agent/README.md
+++ b/roles/agent/README.md
@@ -79,6 +79,13 @@ Define the hostname which will be used to add the host to Checkmk.
 
 Define an IP address which will be added to the host in Checkmk. This is optional, as long as the hostname is DNS-resolvable.
 
+
+    checkmk_agent_host_attributes:
+        ipaddress: "{{ checkmk_agent_host_ip | default(omit) }}"
+        tag_agent: 'cmk-agent'
+
+Define attributes with which the host will be added to Checkmk.
+
 ## Dependencies
 
 <!-- A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles. -->

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -14,6 +14,9 @@ checkmk_agent_configure_firewall: 'true'
 checkmk_agent_prep_legacy: 'false'
 checkmk_agent_delegate_api_calls: localhost
 checkmk_agent_host_name: "{{ inventory_hostname }}"
+checkmk_agent_host_attributes:
+  ipaddress: "{{ checkmk_agent_host_ip | default(omit) }}"
+  tag_agent: 'cmk-agent'
 
 # If you trust your local hostnames, you could also use the following
 # to use the local hostname instead of the inventory hostname:

--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -28,9 +28,7 @@
     automation_secret: "{{ checkmk_agent_pass }}"
     folder: "{{ checkmk_agent_folder | default(omit) }}"
     host_name: "{{ checkmk_agent_host_name }}"
-    attributes:
-      ipaddress: "{{ checkmk_agent_host_ip | default(omit) }}"
-      tag_agent: 'cmk-agent'  # ToDo: Do we want to hardcode this?
+    attributes: "{{ checkmk_agent_host_attributes }}"
   register: checkmk_agent_create_result
   failed_when: checkmk_agent_create_result.failed is true and "The host is already part of the specified target folder" not in checkmk_agent_create_result.msg
   delegate_to: "{{ checkmk_agent_delegate_api_calls }}"


### PR DESCRIPTION
Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
The attributes of a host are hardcoded to set the IP and checkmk agent only. Having the attributes as a variable allows for more customisation when it comes to adding hosts.

## What is the new behavior?
The default behavior is the same. But now that the attributes aren't hardcoded, this can now be used to add hosts in a more customisable manner. Could also possibly used to add SNMP devices, though getting those attributes correct is a bit of a hassle.. But with this simple change making this a variable, a lot is possible.

One example of the possibilities this adds is the option to add labels when creating a host. a `pre_task` could be used to generate labels based on Ansible Facts and these can be added by defining this variable as this on the host:
```yaml
checkmk_agent_host_attributes:
  ipaddress: "{{ checkmk_agent_host_ip | default(omit) }}"
  tag_agent: 'cmk-agent'
  labels: "{{ dict_of_labels_for_this_host }}"
```
I did however notice that this would not update it if the host already exists, so this might be a bug in the module or API that it doesn't update labels if the host already exists, but that is outside the scope of this PR.
