### PR TITLE
[BUGFIX] Fix legacy agent tasks not deploying agent in xinetd

### DIFF
--- a/roles/agent/tasks/legacy.yml
+++ b/roles/agent/tasks/legacy.yml
@@ -1,10 +1,12 @@
 ---
 - name: "Install xinetd"
+  become: true
   ansible.builtin.package:
     name: xinetd
     state: present
 
 - name: "Enable xinetd"
+  become: true
   ansible.builtin.service:
     name: xinetd
     state: started


### PR DESCRIPTION
Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
The legacy tasks omit `become: true` on tasks that do need it. This is fixed in this PR.

The xinetd script is also not always deployed. I was under the impression that the package will automatically run this deploy script on installation, but it doesn't always work.

For example, this is after running the role against a CentOS 7 host:
```
[root@server2 vagrant]# netstat -tulpn
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp        0      0 0.0.0.0:22              0.0.0.0:*               LISTEN      1038/sshd           
tcp        0      0 127.0.0.1:25            0.0.0.0:*               LISTEN      1132/master         
tcp6       0      0 :::22                   :::*                    LISTEN      1038/sshd           
udp        0      0 0.0.0.0:68              0.0.0.0:*                           2780/dhclient       
udp        0      0 127.0.0.1:323           0.0.0.0:*                           645/chronyd         
udp6       0      0 ::1:323                 :::*                                645/chronyd         
```
The following files are present in `/etc/xinetd.d/`:
`chargen-dgram   chargen-stream  daytime-dgram   daytime-stream  discard-dgram   discard-stream  echo-dgram      echo-stream     tcpmux-server   time-dgram      time-stream`

There is no Checkmk agent deployed.
I'm not sure why the package doesn't always do this, I could've sworn it did this automatically. But at best it seems inconsistent, so having the legacy tasks trigger this will guarantee it's deployed.

## What is the new behavior?
A new task is added that triggers the script `/var/lib/cmk-agent/scripts/super-server/setup deploy`.
After this script is ran, the `check-mk-agent` file is added to `/etc/xinetd.d/`.

This will also now restart `xinetd`, for if it was already installed and enabled.
The agent is now listening:
```
[root@server2 vagrant]# netstat -tulpn
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp        0      0 0.0.0.0:22              0.0.0.0:*               LISTEN      1038/sshd           
tcp        0      0 127.0.0.1:25            0.0.0.0:*               LISTEN      1132/master         
tcp6       0      0 :::22                   :::*                    LISTEN      1038/sshd           
tcp6       0      0 :::6556                 :::*                    LISTEN      6970/xinetd         
udp        0      0 0.0.0.0:68              0.0.0.0:*                           2780/dhclient       
udp        0      0 127.0.0.1:323           0.0.0.0:*                           645/chronyd         
udp6       0      0 ::1:323                 :::*                                645/chronyd         
```

This PR includes tags for this new task, which were added in https://github.com/tribe29/ansible-collection-tribe29.checkmk/pull/114, this should be put on hold until that PR is merged! 
Since those commits make the changes hard to read, this is the new `legacy.yml`:
```yaml
---
- name: "Install xinetd"
  become: true
  ansible.builtin.package:
    name: xinetd
    state: present
  tags:
    - install_package
    - install_prerequisites

- name: "Deploy xinetd agent."
  become: true
  ansible.builtin.shell: |
    /var/lib/cmk-agent/scripts/super-server/setup deploy
  args:
    creates: /etc/xinetd.d/check-mk-agent
  tags:
    - deploy_agent

- name: "Restart and enable xinetd"
  become: true
  ansible.builtin.service:
    name: xinetd
    state: restarted
    enabled: true
  tags:
    - enable_service
```