### PR TITLE
Make SSL verification a boolean

### DIFF
--- a/changelogs/fragments/modules.yml
+++ b/changelogs/fragments/modules.yml
@@ -1,9 +1,11 @@
 # https://docs.ansible.com/ansible/latest/community/development_process.html#changelogs-how-to
 
 minor_changes:
-  - Agent role - Enable forced agent installation, skipping all possible constraints, like downgrades.
-  - Agent role - Make Checkmk server port for API calls configurable. By default the ports 80 and 443 are used according to the configured protocol.
-  - Agent role - Enable usage of the `validate_certs` option, available in all modules.
+  - Activation module - Make certificate validation of the Checkmk server configurable.
+  - Discovery module - Make certificate validation of the Checkmk server configurable.
+  - Downtime module - Make certificate validation of the Checkmk server configurable.
+  - Folder module - Make certificate validation of the Checkmk server configurable.
+  - Host module - Make certificate validation of the Checkmk server configurable.
 
 # known_issues:
 #   - This release is still in development and a heavy work in progress.

--- a/plugins/modules/activation.py
+++ b/plugins/modules/activation.py
@@ -32,6 +32,10 @@ options:
         description: Wheather to active foreign changes.
         default: false
         type: bool
+    validate_certs:
+        description: Whether to validate the SSL certificate of the Checkmk server.
+        default: true
+        type: bool
 
 author:
     - Robin Gierse (@robin-tribe29)
@@ -90,6 +94,7 @@ def run_module():
     module_args = dict(
         server_url=dict(type="str", required=True),
         site=dict(type="str", required=True),
+        validate_certs=dict(type="bool", required=False, default=True),
         automation_user=dict(type="str", required=True),
         automation_secret=dict(type="str", required=True, no_log=True),
         sites=dict(type="raw", default=[]),

--- a/plugins/modules/discovery.py
+++ b/plugins/modules/discovery.py
@@ -32,6 +32,10 @@ options:
         type: str
         default: new
         choices: [new, remove, fix_all, refresh, only_host_labels]
+    validate_certs:
+        description: Whether to validate the SSL certificate of the Checkmk server.
+        default: true
+        type: bool
 
 author:
     - Robin Gierse (@robin-tribe29)
@@ -80,6 +84,7 @@ def run_module():
     module_args = dict(
         server_url=dict(type="str", required=True),
         site=dict(type="str", required=True),
+        validate_certs=dict(type="bool", required=False, default=True),
         automation_user=dict(type="str", required=True),
         automation_secret=dict(type="str", required=True, no_log=True),
         host_name=dict(type="str", required=True),

--- a/plugins/modules/downtime.py
+++ b/plugins/modules/downtime.py
@@ -88,6 +88,10 @@ options:
         type: str
         default: present
         choices: [present, absent]
+    validate_certs:
+        description: Whether to validate the SSL certificate of the Checkmk server.
+        default: true
+        type: bool
 
 author:
     - Oliver Gaida (@ogaida)
@@ -405,6 +409,7 @@ def run_module():
     module_args = dict(
         server_url=dict(type="str", required=True),
         site=dict(type="str", required=True),
+        validate_certs=dict(type="bool", required=False, default=True),
         automation_user=dict(type="str", required=True),
         automation_secret=dict(type="str", required=True, no_log=True),
         host_name=dict(type="str", required=True),

--- a/plugins/modules/folder.py
+++ b/plugins/modules/folder.py
@@ -39,6 +39,10 @@ options:
         type: str
         default: present
         choices: [present, absent]
+    validate_certs:
+        description: Whether to validate the SSL certificate of the Checkmk server.
+        default: true
+        type: bool
 
 author:
     - Robin Gierse (@robin-tribe29)
@@ -229,6 +233,7 @@ def run_module():
     module_args = dict(
         server_url=dict(type="str", required=True),
         site=dict(type="str", required=True),
+        validate_certs=dict(type="bool", required=False, default=True),
         automation_user=dict(type="str", required=True),
         automation_secret=dict(type="str", required=True, no_log=True),
         path=dict(type="str", required=True),

--- a/plugins/modules/host.py
+++ b/plugins/modules/host.py
@@ -40,6 +40,10 @@ options:
         type: str
         default: present
         choices: [present, absent]
+    validate_certs:
+        description: Whether to validate the SSL certificate of the Checkmk server.
+        default: true
+        type: bool
 
 author:
     - Robin Gierse (@robin-tribe29)
@@ -230,6 +234,7 @@ def run_module():
     module_args = dict(
         server_url=dict(type="str", required=True),
         site=dict(type="str", required=True),
+        validate_certs=dict(type="bool", required=False, default=True),
         automation_user=dict(type="str", required=True),
         automation_secret=dict(type="str", required=True, no_log=True),
         host_name=dict(type="str", required=True),

--- a/roles/agent/README.md
+++ b/roles/agent/README.md
@@ -29,6 +29,10 @@ The protocol used to connect to your Checkmk site.
 
 The FQDN or IP address of your Checkmk server.
 
+    checkmk_agent_server_validate_certs: 'true'
+
+Whether to validate the SSL certificate of the Checkmk server.
+
     checkmk_agent_site: my_site
 
 The name of your Checkmk site.

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -3,6 +3,7 @@ checkmk_agent_version: "2.1.0p1"
 checkmk_agent_edition: cre
 checkmk_agent_protocol: http
 checkmk_agent_server: localhost
+checkmk_agent_server_validate_certs: 'true'
 checkmk_agent_site: my_site
 checkmk_agent_user: "{{ automation_user | default('automation') }}"
 

--- a/roles/agent/tasks/Debian.yml
+++ b/roles/agent/tasks/Debian.yml
@@ -2,6 +2,7 @@
 - name: "Debian Derivates: Download host-specific Checkmk {{ checkmk_agent_edition | upper }} Agent."
   ansible.builtin.uri:
     url: "{{ checkmk_agent_agent.url.cee }}?host_name={{ inventory_hostname }}&os_type=linux_deb&agent_type=host_name"
+    validate_certs: "{{ checkmk_agent_server_validate_certs | bool }}"
     dest: "{{ checkmk_agent_agent.file.host }}"
     method: GET
     headers:
@@ -30,6 +31,7 @@
 - name: "Debian Derivates: Download GENERIC Checkmk {{ checkmk_agent_edition | upper }} Agent."
   ansible.builtin.uri:
     url: "{{ checkmk_agent_agent.url.cee }}?os_type=linux_deb&agent_type=generic"
+    validate_certs: "{{ checkmk_agent_server_validate_certs | bool }}"
     dest: "{{ checkmk_agent_agent.file.cee }}"
     method: GET
     headers:

--- a/roles/agent/tasks/RedHat.yml
+++ b/roles/agent/tasks/RedHat.yml
@@ -2,6 +2,7 @@
 - name: "RedHat Derivates: Download host-specific Checkmk {{ checkmk_agent_edition | upper }} Agent."
   ansible.builtin.uri:
     url: "{{ checkmk_agent_agent.url.cee }}?host_name={{ inventory_hostname }}&os_type=linux_rpm&agent_type=host_name"
+    validate_certs: "{{ checkmk_agent_server_validate_certs | bool }}"
     dest: "{{ checkmk_agent_agent.file.host }}"
     method: GET
     headers:
@@ -30,6 +31,7 @@
 - name: "RedHat Derivates: Download GENERIC Checkmk {{ checkmk_agent_edition | upper }} Agent."
   ansible.builtin.uri:
     url: "{{ checkmk_agent_agent.url.cee }}?os_type=linux_rpm&agent_type=generic"
+    validate_certs: "{{ checkmk_agent_server_validate_certs | bool }}"
     dest: "{{ checkmk_agent_agent.file.cee }}"
     method: GET
     headers:

--- a/roles/agent/tasks/Suse.yml
+++ b/roles/agent/tasks/Suse.yml
@@ -2,6 +2,7 @@
 - name: "Suse Derivates: Download host-specific Checkmk {{ checkmk_agent_edition | upper }} Agent."
   ansible.builtin.uri:
     url: "{{ checkmk_agent_agent.url.cee }}?host_name={{ inventory_hostname }}&os_type=linux_rpm&agent_type=host_name"
+    validate_certs: "{{ checkmk_agent_server_validate_certs | bool }}"
     dest: "{{ checkmk_agent_agent.file.host }}"
     method: GET
     headers:
@@ -31,6 +32,7 @@
 - name: "Suse Derivates: Download GENERIC Checkmk {{ checkmk_agent_edition | upper }} Agent."
   ansible.builtin.uri:
     url: "{{ checkmk_agent_agent.url.cee }}?os_type=linux_rpm&agent_type=generic"
+    validate_certs: "{{ checkmk_agent_server_validate_certs | bool }}"
     dest: "{{ checkmk_agent_agent.file.cee }}"
     method: GET
     headers:

--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -19,6 +19,7 @@
 - name: "Download Checkmk CRE Agent."
   ansible.builtin.get_url:
     url: "{{ checkmk_agent_agent.url.cre }}"
+    validate_certs: "{{ checkmk_agent_server_validate_certs | bool }}"
     dest: "{{ checkmk_agent_agent.file.cre }}"
     mode: 0640
   when: checkmk_agent_edition == "cre"
@@ -34,6 +35,7 @@
   tribe29.checkmk.host:
     server_url: "{{ checkmk_agent_protocol }}://{{ checkmk_agent_server }}/"
     site: "{{ checkmk_agent_site }}"
+    validate_certs: "{{ checkmk_agent_server_validate_certs | bool }}"
     automation_user: "{{ checkmk_agent_user }}"
     automation_secret: "{{ checkmk_agent_pass }}"
     folder: "{{ checkmk_agent_folder | default(omit) }}"
@@ -112,6 +114,7 @@
   tribe29.checkmk.discovery:
     server_url: "{{ checkmk_agent_protocol }}://{{ checkmk_agent_server }}/"
     site: "{{ checkmk_agent_site }}"
+    validate_certs: "{{ checkmk_agent_server_validate_certs | bool }}"
     automation_user: "{{ checkmk_agent_user }}"
     automation_secret: "{{ checkmk_agent_pass }}"
     host_name: "{{ checkmk_agent_host_name }}"


### PR DESCRIPTION
Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
You can not use the agent role if your Checkmk server uses HTTPS and does not have a certificate trusted by all hosts. Downloading the agent package will fail, as will any tasks that interact with the API.

## What is the new behavior?
A new boolean `checkmk_agent_server_validate_certs` is added, it defaults to true. This is used in every `ansible.builtin.uri` task and decides whether SSL certificates should be trusted.
An option `validate_certs` is also added to all modules in this collection. This does not add any code besides the option and the documentation for it. 

## Other information
The `validate_certs` option in the modules is built into the `ansible.module_utils.urls` Python module. You can see the code that handles this here: https://github.com/ansible/ansible/blob/0c57734819853d410038d175afbe3f8529690fd4/lib/ansible/module_utils/urls.py#L1860
