### PR TITLE
Add a variable for the server port

### DIFF
--- a/changelogs/fragments/agent_role.yml
+++ b/changelogs/fragments/agent_role.yml
@@ -1,0 +1,49 @@
+# https://docs.ansible.com/ansible/latest/community/development_process.html#changelogs-how-to
+
+minor_changes:
+  - Agent role - Enable forced agent installation, skipping all possible constraints, like downgrades.
+  - Agent role - Make Checkmk server port for API calls configurable. By default the ports 80 and 443 are used according to the configured protocol.
+
+# known_issues:
+#   - This release is still in development and a heavy work in progress.
+#   - Discovery module is not feature complete yet.
+#   - Downtime module is not fully idempotent yet. This affects service downtimes and deletions.
+
+## Line Format
+# When writing a changelog entry, use the following format:
+
+# - scope - description starting with a lowercase letter and ending with a period at the very end. Multiple sentences are allowed (https://github.com/reference/to/an/issue or, if there is no issue, reference to a pull request itself).
+
+# The scope is usually a module or plugin name or group of modules or plugins, for example, lookup plugins. While module names can (and should) be mentioned directly (foo_module), plugin names should always be followed by the type (foo inventory plugin).
+
+# For changes that are not really scoped (for example, which affect a whole collection), use the following format:
+
+# - Description starting with an uppercase letter and ending with a dot at the very end. Multiple sentences are allowed (https://github.com/reference/to/an/issue or, if there is no issue, reference to a pull request itself).
+
+
+## Possible keys:
+
+# breaking_changes
+
+#     Changes that break existing playbooks or roles. This includes any change to existing behavior that forces users to update tasks. Displayed in both the changelogs and the Porting Guides.
+# major_changes
+
+#     Major changes to Ansible itself. Generally does not include module or plugin changes. Displayed in both the changelogs and the Porting Guides.
+# minor_changes
+
+#     Minor changes to Ansible, modules, or plugins. This includes new features, new parameters added to modules, or behavior changes to existing parameters.
+# deprecated_features
+
+#     Features that have been deprecated and are scheduled for removal in a future release. Displayed in both the changelogs and the Porting Guides.
+# removed_features
+
+#     Features that were previously deprecated and are now removed. Displayed in both the changelogs and the Porting Guides.
+# security_fixes
+
+#     Fixes that address CVEs or resolve security concerns. Include links to CVE information.
+# bugfixes
+
+#     Fixes that resolve issues.
+# known_issues
+
+#     Known issues that are currently not fixed or will not be fixed.

--- a/roles/agent/README.md
+++ b/roles/agent/README.md
@@ -29,9 +29,9 @@ The protocol used to connect to your Checkmk site.
 
 The FQDN or IP address of your Checkmk server.
 
-    +checkmk_agent_port: "{% if checkmk_agent_protocol == 'https' %}443{% else %}80{% endif %}"
+    checkmk_agent_port: "{% if checkmk_agent_protocol == 'https' %}443{% else %}80{% endif %}"
 
-The port of the web interface of your Checkmk server.
+The port of the web interface of your Checkmk server. Defaults to port 80 for http and port 443 for https.
 
     checkmk_agent_site: my_site
 

--- a/roles/agent/README.md
+++ b/roles/agent/README.md
@@ -29,6 +29,10 @@ The protocol used to connect to your Checkmk site.
 
 The FQDN or IP address of your Checkmk server.
 
+    +checkmk_agent_port: "{% if checkmk_agent_protocol == 'https' %}443{% else %}80{% endif %}"
+
+The port of the web interface of your Checkmk server.
+
     checkmk_agent_site: my_site
 
 The name of your Checkmk site.

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -3,6 +3,7 @@ checkmk_agent_version: "2.1.0p1"
 checkmk_agent_edition: cre
 checkmk_agent_protocol: http
 checkmk_agent_server: localhost
+checkmk_agent_port: "{% if checkmk_agent_protocol == 'https' %}443{% else %}80{% endif %}"
 checkmk_agent_site: my_site
 checkmk_agent_user: "{{ automation_user | default('automation') }}"
 

--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -32,7 +32,7 @@
 
 - name: "Create host on server."
   tribe29.checkmk.host:
-    server_url: "{{ checkmk_agent_protocol }}://{{ checkmk_agent_server }}/"
+    server_url: "{{ checkmk_agent_protocol }}://{{ checkmk_agent_server }}:{{ checkmk_agent_port }}/"
     site: "{{ checkmk_agent_site }}"
     automation_user: "{{ checkmk_agent_user }}"
     automation_secret: "{{ checkmk_agent_pass }}"
@@ -110,7 +110,7 @@
 
 - name: "Discover services and labels on host."
   tribe29.checkmk.discovery:
-    server_url: "{{ checkmk_agent_protocol }}://{{ checkmk_agent_server }}/"
+    server_url: "{{ checkmk_agent_protocol }}://{{ checkmk_agent_server }}:{{ checkmk_agent_port }}/"
     site: "{{ checkmk_agent_site }}"
     automation_user: "{{ checkmk_agent_user }}"
     automation_secret: "{{ checkmk_agent_pass }}"

--- a/roles/agent/vars/main.yml
+++ b/roles/agent/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-checkmk_agent_site_url: "{{ checkmk_agent_protocol }}://{{ checkmk_agent_server }}/{{ checkmk_agent_site }}"
+checkmk_agent_site_url: "{{ checkmk_agent_protocol }}://{{ checkmk_agent_server }}:{{ checkmk_agent_port }}/{{ checkmk_agent_site }}"


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
The port 80 is always used for HTTP and port 443 is always used for HTTPS.

## What is the new behavior?
Just like my other PR https://github.com/tribe29/ansible-collection-tribe29.checkmk/pull/132, this makes the agent role more flexible in certain situations. 
This adds a variable to the agent role `checkmk_agent_port`. It defaults to 80 when `checkmk_agent_protocol` is `http`, and defaults to `443` when `checkmk_agent_protocol` is `https`. If you leave this variable unchanged, it shouldn't affect the role.