### PR TITLE
Only use user password for authentication when secret is not set

### DIFF
--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -70,6 +70,7 @@
     and checkmk_agent_updater_binary.stat.exists | bool
     and checkmk_agent_update | bool
     and (checkmk_agent_pass is defined and checkmk_agent_pass | length)
+    and (checkmk_agent_secret is not defined)
 
 - name: "Register Agent for automatic Upates using Automation Secret."
   become: true
@@ -96,6 +97,7 @@
     and checkmk_agent_controller_binary.stat.exists | bool
     and checkmk_agent_tls | bool
     and (checkmk_agent_pass is defined and checkmk_agent_pass | length)
+    and (checkmk_agent_secret is not defined)
 
 - name: "Register Agent for TLS using Automation Secret."
   become: true


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
When secret and password are both set, the role will fail. With this workaround, the user password will only be taken if no secret was set

<!---
## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
