### PR TITLE
Add tasks to fix RHEL support

### DIFF
--- a/roles/server/README.md
+++ b/roles/server/README.md
@@ -35,7 +35,11 @@ Your credentials to the Checkmk customer portal.
 
     checkmk_server_verify_setup: 'true'
 
-Cryptographically verify the downloaded setup file.
+Cryptographically verify the downloaded Checkmk setup file.
+
+    checkmk_server_epel_gpg_check: 'true'
+
+Cryptographically verify the downloaded epel-release package on RHEL 8.
 
     checkmk_server_configure_firewall: 'true'
 
@@ -81,7 +85,8 @@ Tasks are tagged with the following tags:
 | `include-os-family-vars` | Include OS family specific variables. |
 | `include-rhel-version-vars` | Include RHEL version specific variables. |
 | `set-selinux-boolean` | Set necessary SELinux booleans for Checkmk to work on SELinux enabled systems. |
-| `enable-powertools` | Enable the powertools repository on RHEL based systems. Required for some dependencies of Checkmk. |
+| `enable-repos` | Enable the required external repositories on RHEL based systems. Powertools on RHEL 7 and CentOS 8. CRB and EPEL on RHEL 8. |
+| `checkmk_server_epel_gpg_check` | Download and use GPG key verification for EPEL repository. |
 | `create-sites` | Create sites on the Checkmk server. |
 | `update-sites` | Update sites on the Checkmk server. |
 | `start-sites` | Start sites on the Checkmk server. |

--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -30,3 +30,5 @@ checkmk_server_backup_on_update: 'true'  # Not recommended to disable this optio
 checkmk_server_backup_dir: /tmp
 checkmk_server_backup_opts: '--no-past'
 checkmk_server_allow_downgrades: 'false'
+
+checkmk_server_epel_gpg_check: 'true'

--- a/roles/server/tasks/RedHat.yml
+++ b/roles/server/tasks/RedHat.yml
@@ -1,10 +1,69 @@
 ---
-- name: "Enable powertools repository."
+- block:
+
+  - name: "Enable CodeReady Linux Builder repo on RHEL 8."
+    become: true
+    community.general.rhsm_repository:
+      name: "codeready-builder-for-rhel-{{ ansible_facts.distribution_major_version }}-x86_64-rpms"
+      state: enabled
+    tags:
+      - enable-repos
+
+  - name: "Download EPEL GPG Key on RHEL 8."
+    ansible.builtin.get_url:
+      url: "{{ checkmk_server_epel_gpg_key }}"
+      dest: "/tmp/EPEL-pubkey.gpg"
+      mode: "0640"
+    when: checkmk_server_verify_setup | bool
+    tags:
+      - download-gpg-key
+      - enable-repos
+
+  - name: "Import Checkmk GPG Key on RHEL 8."
+    become: true
+    ansible.builtin.rpm_key:
+      key: "/tmp/EPEL-pubkey.gpg"
+      state: present
+    when: checkmk_server_epel_gpg_check | bool
+    tags:
+      - import-gpg-key
+      - enable-repos
+
+  - name: "Install epel-release from URL on RHEL 8."
+    become: true
+    ansible.builtin.yum:
+      name: "{{ checkmk_server_epel_url }}"
+      state: present
+      disable_gpg_check: "{{ not checkmk_server_epel_gpg_check | bool }}"
+    tags:
+      - enable-repos
+
+  when: |
+    ansible_facts.distribution == "RedHat"
+    and ansible_facts.distribution_major_version == "8"
+
+- name: "Enable powertools repository on CentOS 8."
   become: true
   ansible.builtin.shell: dnf config-manager --set-enabled powertools  # noqa command-instead-of-shell
-  when: ansible_distribution_major_version == "8"
+  when: | # RHEL needs epel and a package URL
+    ansible_facts.distribution != "RedHat"
+    and ansible_distribution_major_version == "8"
   tags:
-    - enable-powertools
+    - enable-repos
+
+- name: "Enable powertools repository on RHEL 7."
+  become: true
+  community.general.rhsm_repository:
+    name: "{{ item }}"
+    state: enabled
+  loop:
+    - "rhel-7-server-optional-rpms"
+    - "rhel-7-server-extras-rpms"
+  when: |
+    ansible_facts.distribution == "RedHat"
+    and ansible_facts.distribution_major_version == "7"
+  tags:
+    - enable-repos
 
 - name: "Install Checkmk Server."
   become: true
@@ -26,6 +85,7 @@
     - set-selinux-boolean
 
 - name: "Make sure firewalld is started and enabled"
+  become: true
   ansible.builtin.systemd:
     name: firewalld
     state: started

--- a/roles/server/tasks/RedHat.yml
+++ b/roles/server/tasks/RedHat.yml
@@ -1,5 +1,6 @@
 ---
-- block:
+- name: "Enable repositories on RHEL 8."
+  block:
 
   - name: "Enable CodeReady Linux Builder repo on RHEL 8."
     become: true

--- a/roles/server/tasks/sites.yml
+++ b/roles/server/tasks/sites.yml
@@ -21,6 +21,7 @@
     omd version {{ item.name }} | egrep -o '[^ ]+$'
   args:
     executable: /bin/bash
+  no_log: true
   loop: "{{ checkmk_server_sites }}"
   changed_when: "checkmk_server_sites_versions.stdout != item.version + '.' + checkmk_server_edition"
   when: item.state != "absent"

--- a/roles/server/vars/RedHat.yml
+++ b/roles/server/vars/RedHat.yml
@@ -10,18 +10,26 @@ checkmk_server_ports:
 checkmk_server_prerequisites_per_distro:
   RedHat:
     - firewalld
-    - epel-release
-    - python3-libsemanage
     - dnf-plugins-core
+    - python3-libsemanage
+  CentOS-7:
+    - firewalld
+    - dnf-plugins-core
+    - libsemanage-python
+  CentOS-8:
+    - firewalld
+    - dnf-plugins-core
+    - python3-libsemanage
   RedHat-7:
     - firewalld
-    - epel-release
     - libsemanage-python
   RedHat-8:
     - firewalld
-    - epel-release
-    - python3-libsemanage
     - dnf-plugins-core
+    - python3-libsemanage
 
-checkmk_server_prerequisites: "{{ checkmk_server_prerequisites_per_distro[ansible_facts.os_family ~ '-' ~ ansible_facts.distribution_major_version] | default(
-  checkmk_server_prerequisites_per_distro[ansible_facts.os_family]) }}"
+checkmk_server_prerequisites: "{{ checkmk_server_prerequisites_per_distro[ansible_facts.distribution ~ '-' ~ ansible_facts.distribution_major_version]
+  | default( checkmk_server_prerequisites_per_distro[ansible_facts.distribution]) }}"
+
+checkmk_server_epel_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts.distribution_major_version }}.noarch.rpm"
+checkmk_server_epel_gpg_key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_facts.distribution_major_version }}"


### PR DESCRIPTION

## Pull request type
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
RHEL 7 and RHEL 8 have different repositories and require other tasks to get Checkmk to install.  
CentOS 7 does not require any repositories, but RHEL 7 does.  
RHEL 8 also requires different repositories than CentOS 8, namely CRB and EPEL instead of powertools.  

## What is the new behavior?
* CRB is enabled on RHEL 8.  
* EPEL is enabled on RHEL 8.
  This requires a package URL, as epel-release is not a package in RHEL. https://www.redhat.com/en/blog/whats-epel-and-how-do-i-use-it  
* Powertools is enabled on CentOS 8.  
* Powertools (Extra repos) is enabled on CentOS 7.  

## Other information
I've tested the changes on CentOS 7, CentOS 8 Stream, RHEL 7.9 and RHEL 8.6.  
If you want to test these changes in Vagrant, I wrote a little guide to get RHEL in Vagrant: https://gist.github.com/diademiemi/799949a7a3116eb301c6cbc3b9884ca5  

Checkmk does not support RHEL 9 and it's derivatives yet, but once it does it should be largely the same as CentOS & RHEL 8.