### PR TITLE
allow to specify the position of created rules

### DIFF
--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -453,8 +453,8 @@ def run_module():
                         module, "Position 'folder' is not valid with 'state=present'"
                     )
                 move["folder"] = rule.get("folder")
-            if move.get("rule_id") is not None:
-                exit_failed(module, "Position does not support 'rule_id'")
+                if move.get("rule_id") is not None:
+                    exit_failed(module, "Position does not support 'rule_id'")
 
     # Get ID of rule that is the same as the given options
     rule_id = get_existing_rule(module, base_url, headers, ruleset, rule)

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -36,11 +36,6 @@ options:
         description: Position of the rule in the folder
         required: false
         type: dict
-        choices:
-            - {"position": "bottom_of_folder"} 
-            - {"position": "top_of_folder"}
-            - {"position": "after_specific_rule", "rule_id": str}
-            - {"position": "before_specific_rule", "rule_id": str}
     state:
         description: State of the rule.
         choices: [present, absent]
@@ -233,13 +228,13 @@ def move_rule(module, base_url, headers, rule, rule_id, position):
     api_endpoint = "/objects/rule/" + rule_id + "/actions/move/invoke"
 
     if position.get("position") not in [
-            "bottom_of_folder",
-            "top_of_folder",
-            "after_specific_rule",
-            "before_specific_rule",
+        "bottom_of_folder",
+        "top_of_folder",
+        "after_specific_rule",
+        "before_specific_rule",
     ] or (
-            position.get("position") in ["after_specific_rule", "before_specific_rule"]
-            and (position.get("rule_id") is None or position.get("rule_id") == "")
+        position.get("position") in ["after_specific_rule", "before_specific_rule"]
+        and (position.get("rule_id") is None or position.get("rule_id") == "")
     ):
         exit_failed(module, "Position parameter format is not valid")
 
@@ -248,8 +243,6 @@ def move_rule(module, base_url, headers, rule, rule_id, position):
 
     url = base_url + api_endpoint
 
-    # although we already have the rule id and an etag
-    # we still need to specify a folder
     position["folder"] = rule.get("folder")
 
     response, info = fetch_url(

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -275,7 +275,8 @@ def get_existing_rule(module, base_url, headers, ruleset, rule):
         for r in rules.get("value"):
             # Check if conditions, properties and values are the same
             if (
-                sorted(r["extensions"]["conditions"]) == sorted(rule["conditions"])
+                r["folder"] == rule["folder"]
+                and sorted(r["extensions"]["conditions"]) == sorted(rule["conditions"])
                 and sorted(r["extensions"]["properties"]) == sorted(rule["properties"])
                 and sorted(r["extensions"]["value_raw"]) == sorted(rule["value_raw"])
             ):

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -52,7 +52,7 @@ options:
                 description:
                     - Put the created/moved rule C(before) or C(after) this rule_id.
                     - Required when I(position) is C(before) or C(after).
-                    - Mutually exclusive with I(position=before) and I(after). 
+                    - Mutually exclusive with I(position=before) and I(after).
                 type: str
             folder:
                 description:
@@ -96,7 +96,7 @@ EXAMPLES = r"""
             "documentation_url": "https://github.com/tribe29/ansible-collection-tribe29.checkmk/blob/main/plugins/modules/rules.py"
         }
         value_raw: "{'levels': (80.0, 90.0)}"
-    move: 
+    move:
         position: "top"
     state: "present"
     register: response
@@ -163,7 +163,7 @@ EXAMPLES = r"""
         position: "top"
         folder: "~test"
 
-# TODO: delete rule "123456789abcdef" 
+# TODO: delete rule "123456789abcdef"
 - name: "Delete a rule by ID."
   tribe29.checkmk.rule:
     server_url: "http://localhost/"
@@ -327,7 +327,7 @@ def get_rule_etag(module, base_url, headers, rule_id):
 def move_rule(module, base_url, headers, rule_id, move):
     api_endpoint = "/objects/rule/" + rule_id + "/actions/move/invoke"
 
-    if move.get("position") not in ["bottom", "top", "after", "before",] or (
+    if move.get("position") not in ["bottom", "top", "after", "before"] or (
         move.get("position") in ["after", "before"]
         and (move.get("rule_id") is None or move.get("rule_id") == "")
     ):

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -224,17 +224,17 @@ except ImportError:  # For Python 3
     from urllib.parse import urlencode
 
 
-def exit_failed(module, msg, content={}):
+def exit_failed(module, msg, content=None):
     result = {"msg": msg, "content": content, "changed": False, "failed": True}
     module.fail_json(**result)
 
 
-def exit_changed(module, msg, content={}):
+def exit_changed(module, msg, content=None):
     result = {"msg": msg, "content": content, "changed": True, "failed": False}
     module.exit_json(**result)
 
 
-def exit_ok(module, msg, content={}):
+def exit_ok(module, msg, content=None):
     result = {"msg": msg, "content": content, "changed": False, "failed": False}
     module.exit_json(**result)
 

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -232,16 +232,14 @@ def get_rule_etag(module, base_url, headers, rule_id):
 def move_rule(module, base_url, headers, rule, rule_id, position):
     api_endpoint = "/objects/rule/" + rule_id + "/actions/move/invoke"
 
-    if (
-        position.get("position") not in [
+    if position.get("position") not in [
             "bottom_of_folder",
             "top_of_folder",
             "after_specific_rule",
             "before_specific_rule",
-        ] or (
+    ] or (
             position.get("position") in ["after_specific_rule", "before_specific_rule"]
             and (position.get("rule_id") is None or position.get("rule_id") == "")
-        )
     ):
         exit_failed(module, "Position parameter format is not valid")
 

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -57,7 +57,7 @@ options:
             folder:
                 description:
                     - Folder the rule should be moved to.
-                    - Mutually exclusive with I(state=present). 
+                    - Mutually exclusive with I(state=present).
     state:
         description: State of the rule.
         choices: [present, absent]

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -331,13 +331,10 @@ def run_module():
 
     # Get ID of rule that is the same as the given options
     content = get_existing_rule(module, base_url, headers, ruleset, rule)
-    if content is not None:
-        rule_id = content.get("id")
-    else:
-        rule_id = None
 
     # If rule exists
-    if rule_id is not None:
+    if content is not None:
+        rule_id = content.get("id")
         # If state is absent, delete the rule
         if module.params.get("state") == "absent":
             delete_rule(module, base_url, headers, rule_id)

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -448,6 +448,7 @@ def run_module():
                 exit_failed(module, "Position does not support 'folder'")
         if module.params.get("state") == "present":
             if move.get("position") in ["top", "bottom"]:
+                # always move the rule within the creation folder
                 if move.get("folder") is not None:
                     exit_failed(
                         module, "Position 'folder' is not valid with 'state=present'"

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -408,6 +408,13 @@ def run_module():
                     ],
                     mutually_exclusive=[("folder", "rule_id")],
                     apply_defaults=True,
+                    deprecated_aliases=[
+                        dict(
+                            name="folder",
+                            collection_name="tribe29.checkmk",
+                            version="1.0.0",
+                        ),
+                    ],
                 ),
             ),
             mutually_exclusive=[("folder", "location")],

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -26,9 +26,11 @@ extends_documentation_fragment: [tribe29.checkmk.common]
 options:
     rule:
         description: Definition of the rule as returned by the Checkmk API.
+        required: true
         type: dict
     ruleset:
         description: Name of the ruleset to manage.
+        required: true
         type: str
     move:
         description:

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -275,8 +275,7 @@ def get_existing_rule(module, base_url, headers, ruleset, rule):
         for r in rules.get("value"):
             # Check if conditions, properties and values are the same
             if (
-                r["folder"] == rule["folder"]
-                and sorted(r["extensions"]["conditions"]) == sorted(rule["conditions"])
+                sorted(r["extensions"]["conditions"]) == sorted(rule["conditions"])
                 and sorted(r["extensions"]["properties"]) == sorted(rule["properties"])
                 and sorted(r["extensions"]["value_raw"]) == sorted(rule["value_raw"])
             ):

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -36,11 +36,11 @@ options:
         description:
           - Move the rule at the specified location.
           - By default rules are created at the bottom of the folder.
-          - Mutually exclusive with state: absent.
+          - Mutually exclusive with I(state=absent).
         type: dict
         suboptions:
             position:
-                description: Position of the rule in the folder. 
+                description: Position of the rule in the folder.
                 required: true
                 type: str
                 choices:
@@ -50,9 +50,9 @@ options:
                     - "after"
             rule_id:
                 description:
-                    - Put the created/moved rule before or after this rule_id.
-                    - Required when position is before or after.
-                    - Mutually exclusive with position: before and after. 
+                    - Put the created/moved rule C(before) or C(after) this rule_id.
+                    - Required when I(position) is C(before) or C(after).
+                    - Mutually exclusive with I(position=before) and I(after). 
                 type: str
             folder:
                 description:

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -36,11 +36,11 @@ options:
         description:
           - Move the rule at the specified location.
           - By default rules are created at the bottom of the folder.
-          - Mutually exclusive with I(state: absent)
+          - Mutually exclusive with state: absent.
         type: dict
         suboptions:
             position:
-                description: Position of the rule in the folder 
+                description: Position of the rule in the folder. 
                 required: true
                 type: str
                 choices:
@@ -50,9 +50,9 @@ options:
                     - "after"
             rule_id:
                 description:
-                    - Put the created/moved rule C(before) or C(after) this rule_id.
-                    - Required when I(position) is C(before) or C(after).
-                    - Mutually exclusive with I(position: before) and I(after) 
+                    - Put the created/moved rule before or after this rule_id.
+                    - Required when position is before or after.
+                    - Mutually exclusive with position: before and after. 
                 type: str
             folder:
                 description:

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -32,6 +32,14 @@ options:
         description: Name of the ruleset to manage.
         required: true
         type: str
+    position:
+        description: Position of the rule in the folder
+        required: false
+        type: dict
+        choices: [{"position":"bottom_of_folder"}, 
+                  {"position":"top_of_folder"},
+                  {"position":"after_specific_rule", "rule_id":string},
+                  {"position":"before_specific_rule", "rule_id":string}]
     state:
         description: State of the rule.
         choices: [present, absent]
@@ -51,6 +59,7 @@ EXAMPLES = r"""
     automation_user: "automation"
     automation_secret: "$SECRET"
     ruleset: "checkgroup_parameters:memory_percentage_used"
+    position: { "top_of_folder" }
     rule:
         conditions: {
             "host_labels": [],
@@ -215,17 +224,9 @@ def get_rule_etag(module, base_url, headers, rule_id):
             "Error calling API. HTTP code %d. Details: %s, "
             % (info["status"], info["body"]),
         )
-    print(" RULE ETAG : %s" % info["etag"])
     return info["etag"]
 
 def move_rule(module, base_url, headers, rule_id, position):
-
-    # position parameter valid formats:
-    # 
-    # position: { "position": "bottom_of_folder" }
-    # position: { "position": "top_of_folder" }
-    # position: { "position": "after_specific_rule", "rule_id" : string }
-    # position: { "position": "before_specific_rule", "rule_id" : string }
 
     if ( position.get("position") not in [ "bottom_of_folder", "top_of_folder", "after_specific_rule",  "before_specific_rule" ]
         or ( position.get("position") in [ "after_specific_rule",  "before_specific_rule" ]

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -33,7 +33,15 @@ options:
         required: true
         type: str
     position:
-        description: Position of the rule in the folder
+        description:
+            - Position of the rule in the list. Valid formats:
+
+              {"position": "top_of_folder"}
+              {"position": "bottom_of_folder"}
+              {"position": "before_specific_rule", rule_id: str}
+              {"position": "after_specific_rule", rule_id: str}
+
+              The rule_id can be obtained from the output of a previously created rule.
         required: false
         type: dict
     state:
@@ -76,6 +84,11 @@ EXAMPLES = r"""
         }
         value_raw: "{'levels': (80.0, 90.0)}"
     state: "present"
+    register: response
+
+- name: Show the ID of the new rule
+  debug:
+    msg: "RULE ID : {{ response.content.id }}"
 
 # Delete first rule in this ruleset.
 - name: "Delete a rule."
@@ -113,6 +126,7 @@ msg:
     type: str
     returned: always
     sample: 'Rule created.'
+
 content:
     description: The Response body from the API when creating or moving a rule, or when a rule already exists.
     type: dict
@@ -179,7 +193,7 @@ def get_existing_rule(module, base_url, headers, ruleset, rule):
                 and sorted(r["extensions"]["properties"]) == sorted(rule["properties"])
                 and sorted(r["extensions"]["value_raw"]) == sorted(rule["value_raw"])
             ):
-                # If they are the same, return the ID
+                # If they are the same, return the content
                 return r
     return None
 

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -229,7 +229,7 @@ def get_rule_etag(module, base_url, headers, rule_id):
     return info["etag"]
 
 
-def move_rule(module, base_url, headers, rule_id, rule, position):
+def move_rule(module, base_url, headers, rule, rule_id, position):
     api_endpoint = "/objects/rule/" + rule_id + "/actions/move/invoke"
 
     if (

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -55,7 +55,7 @@ EXAMPLES = r"""
     automation_user: "automation"
     automation_secret: "$SECRET"
     ruleset: "checkgroup_parameters:memory_percentage_used"
-    position: { "top_of_folder" }
+    position: { "position": "top_of_folder" }
     rule:
         conditions: {
             "host_labels": [],

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -55,7 +55,7 @@ EXAMPLES = r"""
     automation_user: "automation"
     automation_secret: "$SECRET"
     ruleset: "checkgroup_parameters:memory_percentage_used"
-    position: { "name": "top_of_folder" }
+    position: { "position": "top_of_folder" }
     rule:
         conditions: {
             "host_labels": [],
@@ -230,13 +230,13 @@ def get_rule_etag(module, base_url, headers, rule_id):
 def move_rule(module, base_url, headers, rule_id, position):
     api_endpoint = "/objects/rule/" + rule_id + "/actions/move/invoke"
 
-    if position.get("name") not in [
+    if position.get("position") not in [
         "bottom_of_folder",
         "top_of_folder",
         "after_specific_rule",
         "before_specific_rule",
     ] or (
-        position.get("name") in ["after_specific_rule", "before_specific_rule"]
+        position.get("position") in ["after_specific_rule", "before_specific_rule"]
         and (position.get("rule_id") is None or position.get("rule_id") == "")
     ):
         exit_failed(module, "Position parameter mismatch")
@@ -331,7 +331,10 @@ def run_module():
 
     # Get ID of rule that is the same as the given options
     content = get_existing_rule(module, base_url, headers, ruleset, rule)
-    rule_id = content.get("id")
+    if content is not None:
+        rule_id = content.get("id")
+    else:
+        rule_id = None
 
     # If rule exists
     if rule_id is not None:


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

No way to specify the position of the rule in the rule folder, so it is always created at the bottom.

## What is the new behavior?

There is a new "position" parameter to specify the position of the rule.

My use case was to create service discovery rules before the generic, built-in, two-hours rule.

I've added two functions to rules.py

get_rule_etag : gets the rule ETag needed for the next operation (could be useful elsewhere)
move_rule: move the rule to the specified location as defined in the API documentation

I also added a new parameter I've called "position", it's a dict with the position and a rule_id (only for moves that need it: before_specific_rule and after_specific_rule).

Please review the PR. Suggestions/requests are welcome.

## Other information

Tested with CheckMK 2.1p14