### PR TITLE
Make module names more consistent using aliases.

### DIFF
--- a/changelogs/fragments/module_options.yml
+++ b/changelogs/fragments/module_options.yml
@@ -1,0 +1,45 @@
+# https://docs.ansible.com/ansible/latest/community/development_process.html#changelogs-how-to
+
+major_changes:
+  - The host module now uses `name` instead of `host_name`. The latter is retained as an alias but will be removed with a future release.
+  - The folder module now uses `name` instead of `title`. The latter is retained as an alias until further notice.
+
+## Line Format
+
+# When writing a changelog entry, use the following format:
+
+# - scope - description starting with a uppercase letter and ending with a period at the very end. Multiple sentences are allowed.
+
+# The scope is usually a module or plugin name or group of modules or plugins, for example, lookup plugins. While module names can (and should) be mentioned directly (foo_module), plugin names should always be followed by the type (foo inventory plugin).
+
+# For changes that are not really scoped (for example, which affect a whole collection), use the following format:
+
+# - Description starting with an uppercase letter and ending with a dot at the very end. Multiple sentences are allowed.
+
+
+## Possible keys:
+
+# breaking_changes
+
+#     Changes that break existing playbooks or roles. This includes any change to existing behavior that forces users to update tasks. Displayed in both the changelogs and the Porting Guides.
+# major_changes
+
+#     Major changes to Ansible itself. Generally does not include module or plugin changes. Displayed in both the changelogs and the Porting Guides.
+# minor_changes
+
+#     Minor changes to Ansible, modules, or plugins. This includes new features, new parameters added to modules, or behavior changes to existing parameters.
+# deprecated_features
+
+#     Features that have been deprecated and are scheduled for removal in a future release. Displayed in both the changelogs and the Porting Guides.
+# removed_features
+
+#     Features that were previously deprecated and are now removed. Displayed in both the changelogs and the Porting Guides.
+# security_fixes
+
+#     Fixes that address CVEs or resolve security concerns. Include links to CVE information.
+# bugfixes
+
+#     Fixes that resolve issues.
+# known_issues
+
+#     Known issues that are currently not fixed or will not be fixed.

--- a/playbooks/demo.yml
+++ b/playbooks/demo.yml
@@ -24,7 +24,7 @@
         automation_user: "{{ automation_user }}"
         automation_secret: "{{ automation_secret }}"
         path: "{{ item.path }}"
-        title: "{{ item.title }}"
+        name: "{{ item.name }}"
         state: "present"
       delegate_to: localhost
       run_once: 'yes'
@@ -36,7 +36,7 @@
         site: "{{ site }}"
         automation_user: "{{ automation_user }}"
         automation_secret: "{{ automation_secret }}"
-        host_name: "{{ inventory_hostname }}"
+        name: "{{ inventory_hostname }}"
         folder: "{{ checkmk_folder_path }}"
         attributes:
           site: "{{ site }}"
@@ -91,7 +91,7 @@
         site: "{{ site }}"
         automation_user: "{{ automation_user }}"
         automation_secret: "{{ automation_secret }}"
-        host_name: "{{ inventory_hostname }}"
+        name: "{{ inventory_hostname }}"
         folder: "{{ checkmk_folder_path }}"
         attributes:
           site: "{{ site }}"
@@ -106,7 +106,7 @@
         site: "{{ site }}"
         automation_user: "{{ automation_user }}"
         automation_secret: "{{ automation_secret }}"
-        host_name: "{{ inventory_hostname }}"
+        name: "{{ inventory_hostname }}"
         folder: "/bar"
         state: "present"
       delegate_to: localhost
@@ -172,7 +172,7 @@
         site: "{{ site }}"
         automation_user: "{{ automation_user }}"
         automation_secret: "{{ automation_secret }}"
-        host_name: "{{ inventory_hostname }}"
+        name: "{{ inventory_hostname }}"
         folder: "{{ checkmk_folder_path }}"
         state: "absent"
       delegate_to: localhost
@@ -184,7 +184,7 @@
         automation_user: "{{ automation_user }}"
         automation_secret: "{{ automation_secret }}"
         path: "{{ item.path }}"
-        title: "{{ item.title }}"
+        name: "{{ item.name }}"
         state: "absent"
       register: testout
       delegate_to: localhost

--- a/playbooks/hosts
+++ b/playbooks/hosts
@@ -1,3 +1,4 @@
+[test]
 test1.tld checkmk_folder_path="/test" 
 test2.tld checkmk_folder_path="/foo" 
 test3.tld checkmk_folder_path="/bar" 

--- a/plugins/modules/folder.py
+++ b/plugins/modules/folder.py
@@ -27,9 +27,10 @@ options:
         description: The full path to the folder you want to manage. Pay attention to the leading C(/) and avoid trailing C(/).
         required: true
         type: str
-    title:
-        description: The title of your folder. If omitted defaults to the folder name.
+    name:
+        description: The name of your folder. If omitted defaults to the folder name.
         type: str
+        aliases: [title]
     attributes:
         description: The attributes of your folder as described in the API documentation.
         type: raw
@@ -54,7 +55,7 @@ EXAMPLES = r"""
     automation_user: "automation"
     automation_secret: "$SECRET"
     path: "/my_folder"
-    title: "My Folder"
+    name: "My Folder"
     state: "present"
 
 # Create a folder who's hosts should be hosted on a remote site.
@@ -65,7 +66,7 @@ EXAMPLES = r"""
     automation_user: "automation"
     automation_secret: "$SECRET"
     path: "/my_remote_folder"
-    title: "My Remote Folder"
+    name: "My Remote Folder"
     attributes:
       site: "my_remote_site"
     state: "present"
@@ -163,11 +164,11 @@ def get_current_folder_state(module, base_url, headers):
 def set_folder_attributes(module, attributes, base_url, headers):
     parent, foldername = cleanup_path(module.params["path"])
     path_for_url = module.params["path"].replace("/", "~")
-    title = module.params.get("title", foldername)
+    name = module.params.get("name", foldername)
 
     api_endpoint = "/objects/folder_config/" + path_for_url
     params = {
-        "title": title,
+        "name": name,
         "attributes": attributes,
     }
     url = base_url + api_endpoint
@@ -186,12 +187,12 @@ def set_folder_attributes(module, attributes, base_url, headers):
 
 def create_folder(module, attributes, base_url, headers):
     parent, foldername = cleanup_path(module.params["path"])
-    title = module.params.get("title", foldername)
+    name = module.params.get("name", foldername)
 
     api_endpoint = "/domain-types/folder_config/collections/all"
     params = {
         "name": foldername,
-        "title": title,
+        "title": name,
         "parent": parent,
         "attributes": attributes,
     }
@@ -233,7 +234,11 @@ def run_module():
         automation_user=dict(type="str", required=True),
         automation_secret=dict(type="str", required=True, no_log=True),
         path=dict(type="str", required=True),
-        title=dict(type="str"),
+        name=dict(
+            type="str",
+            required=False,
+            aliases=["title"],
+        ),
         attributes=dict(type="raw", default=[]),
         state=dict(type="str", default="present", choices=["present", "absent"]),
     )

--- a/plugins/modules/host.py
+++ b/plugins/modules/host.py
@@ -23,10 +23,11 @@ description:
 extends_documentation_fragment: [tribe29.checkmk.common]
 
 options:
-    host_name:
+    name:
         description: The host you want to manage.
         required: true
         type: str
+        aliases: [host_name]
     folder:
         description: The folder your host is located in.
         type: str
@@ -56,7 +57,7 @@ EXAMPLES = r"""
     site: "my_site"
     automation_user: "automation"
     automation_secret: "$SECRET"
-    host_name: "my_host"
+    name: "my_host"
     folder: "/"
     state: "present"
 
@@ -67,7 +68,7 @@ EXAMPLES = r"""
     site: "my_site"
     automation_user: "automation"
     automation_secret: "$SECRET"
-    host_name: "my_host"
+    name: "my_host"
     attributes:
       alias: "My Host"
       ipaddress: "127.0.0.1"
@@ -81,7 +82,7 @@ EXAMPLES = r"""
     site: "my_site"
     automation_user: "automation"
     automation_secret: "$SECRET"
-    host_name: "my_host"
+    name: "my_host"
     attributes:
       site: "my_remote_site"
     folder: "/"
@@ -123,7 +124,7 @@ def get_current_host_state(module, base_url, headers):
     current_folder = "/"
     etag = ""
 
-    api_endpoint = "/objects/host_config/" + module.params.get("host_name")
+    api_endpoint = "/objects/host_config/" + module.params.get("name")
     parameters = "?effective_attributes=true"
     url = base_url + api_endpoint + parameters
 
@@ -153,7 +154,7 @@ def get_current_host_state(module, base_url, headers):
 
 
 def set_host_attributes(module, attributes, base_url, headers):
-    api_endpoint = "/objects/host_config/" + module.params.get("host_name")
+    api_endpoint = "/objects/host_config/" + module.params.get("name")
     params = {
         "attributes": attributes,
     }
@@ -173,7 +174,7 @@ def set_host_attributes(module, attributes, base_url, headers):
 
 def move_host(module, base_url, headers):
     api_endpoint = "/objects/host_config/%s/actions/move/invoke" % module.params.get(
-        "host_name"
+        "name"
     )
     params = {
         "target_folder": module.params.get("folder", "/"),
@@ -196,7 +197,7 @@ def create_host(module, attributes, base_url, headers):
     api_endpoint = "/domain-types/host_config/collections/all"
     params = {
         "folder": module.params.get("folder", "/"),
-        "host_name": module.params.get("host_name"),
+        "host_name": module.params.get("name"),
         "attributes": attributes,
     }
     url = base_url + api_endpoint
@@ -214,7 +215,7 @@ def create_host(module, attributes, base_url, headers):
 
 
 def delete_host(module, base_url, headers):
-    api_endpoint = "/objects/host_config/" + module.params.get("host_name")
+    api_endpoint = "/objects/host_config/" + module.params.get("name")
     url = base_url + api_endpoint
 
     response, info = fetch_url(module, url, data=None, headers=headers, method="DELETE")
@@ -248,7 +249,18 @@ def run_module():
         validate_certs=dict(type="bool", required=False, default=True),
         automation_user=dict(type="str", required=True),
         automation_secret=dict(type="str", required=True, no_log=True),
-        host_name=dict(type="str", required=True),
+        name=dict(
+            type="str",
+            required=True,
+            aliases=["host_name"],
+            deprecated_aliases=[
+                {
+                    "name": "host_name",
+                    "date": "2024-01-01",
+                    "collection_name": "tribe29.checkmk",
+                }
+            ],
+        ),
         attributes=dict(type="raw", default=[]),
         folder=dict(type="str", default="/"),
         state=dict(type="str", default="present", choices=["present", "absent"]),

--- a/tests/integration/targets/folder/tasks/test.yml
+++ b/tests/integration/targets/folder/tasks/test.yml
@@ -9,7 +9,7 @@
     automation_user: "{{ automation_user }}"
     automation_secret: "{{ automation_secret }}"
     path: "{{ item.path }}"
-    title: "{{ item.title }}"
+    name: "{{ item.name }}"
     state: "present"
   delegate_to: localhost
   run_once: true
@@ -34,7 +34,7 @@
     automation_user: "{{ automation_user }}"
     automation_secret: "{{ automation_secret }}"
     path: "{{ item.path }}"
-    title: "{{ item.title }}"
+    name: "{{ item.name }}"
     state: "absent"
   delegate_to: localhost
   run_once: true

--- a/tests/integration/targets/folder/vars/main.yml
+++ b/tests/integration/targets/folder/vars/main.yml
@@ -11,14 +11,14 @@ automation_secret: "d7589df1-01db-4eda-9858-dbcff8d0c361"
 
 checkmk_folders:
   - path: /test
-    title: Test
+    name: Test
   - path: /foo
-    title: Foo
+    name: Foo
   - path: /bar
-    title: Bar
+    name: Bar
   - path: /foo/bar
-    title: Bar
+    name: Bar
   - path: /bar/foo
-    title: Foo
+    name: Foo
   - path: /foo/bar/treasure
-    title: Treasure
+    name: Treasure

--- a/tests/integration/targets/host/tasks/test.yml
+++ b/tests/integration/targets/host/tasks/test.yml
@@ -5,7 +5,7 @@
     site: "{{ outer_item.site }}"
     automation_user: "{{ automation_user }}"
     automation_secret: "{{ automation_secret }}"
-    host_name: "{{ item.name }}"
+    name: "{{ item.name }}"
     folder: "{{ item.folder }}"
     attributes:
       site: "{{ outer_item.site }}"
@@ -33,7 +33,7 @@
     site: "{{ outer_item.site }}"
     automation_user: "{{ automation_user }}"
     automation_secret: "{{ automation_secret }}"
-    host_name: "{{ item.name }}"
+    name: "{{ item.name }}"
     folder: "{{ item.folder }}"
     state: "absent"
   delegate_to: localhost


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!---
Please use the devel branch as the merge target!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, if people are using the branch directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #180 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The host module now uses `name` instead of `host_name`. The latter is retained as an alias but will be removed with a future release.
- The folder module now uses `name` instead of `title`. The latter is retained as an alias until further notice.

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
