### PR TITLE
Fix rules comparison for creation and deletion

### DIFF
--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -320,7 +320,7 @@ def create_rule(module, base_url, headers, ruleset, rule):
 
     # if existing rule, delete new rule and return existing id
     if e:
-        delete_rule(module, base_url, headers, r["id"])
+        delete_rule_by_id(module, base_url, headers, r["id"])
         return (e["id"], existed)
 
     # else return new rule id
@@ -530,7 +530,7 @@ def run_module():
             if location["position"] != "bottom":
                 move_rule(module, base_url, headers, rule_id, location)
             exit_changed(module, "Created rule", rule_id)
-        exit_ok("Rule already exists")
+        exit_ok(module,"Rule already exists")
 
     # Fallback
     exit_failed(module, "Unknown error")

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -340,7 +340,7 @@ def delete_rule(module, base_url, headers, ruleset, rule):
         delete_rule_by_id(module, base_url, headers, e["id"])
         return deleted
     else:
-        delete_rule_by_id(module, base_url, headers, e["id"])
+        delete_rule_by_id(module, base_url, headers, r["id"])
         return not deleted
 
 

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -262,7 +262,8 @@ def get_existing_rule(module, base_url, headers, ruleset, rule):
         # Loop through all rules
         for r in rules.get("value"):
             if (
-                r["extensions"]["conditions"] == rule["extensions"]["conditions"]
+                r["id"] != rule["id"]
+                and r["extensions"]["conditions"] == rule["extensions"]["conditions"]
                 and r["extensions"]["properties"] == rule["extensions"]["properties"]
                 and r["extensions"]["folder"] == rule["extensions"]["folder"]
                 and r["extensions"]["value_raw"] == rule["extensions"]["value_raw"]

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -511,7 +511,7 @@ def run_module():
         if deleted:
             exit_changed(module, "Rule deleted")
         else:
-            exit_ok(module, "Rule did not exist")
+            exit_ok(module, "Rule does not exist")
     # If state is present, create the rule
     elif module.params.get("state") == "present":
         (rule_id, created) = create_rule(module, base_url, headers, ruleset, rule)

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -265,7 +265,8 @@ def get_existing_rule(module, base_url, headers, ruleset, rule):
             if (
                 r["id"] != rule["id"]
                 and r["extensions"]["conditions"] == rule["extensions"]["conditions"]
-                and r["extensions"]["properties"] == rule["extensions"]["properties"]
+                and r["extensions"]["properties"]["disabled"]
+                == rule["extensions"]["properties"]["disabled"]
                 and r["extensions"]["folder"] == rule["extensions"]["folder"]
                 and r["extensions"]["value_raw"] == rule["extensions"]["value_raw"]
             ):
@@ -519,7 +520,7 @@ def run_module():
             if location["position"] != "bottom":
                 move_rule(module, base_url, headers, rule_id, location)
             exit_changed(module, "Rule created", rule_id)
-        exit_ok(module,"Rule already exists")
+        exit_ok(module, "Rule already exists")
 
     # Fallback
     exit_failed(module, "Unknown error")

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -520,7 +520,7 @@ def run_module():
             if location["position"] != "bottom":
                 move_rule(module, base_url, headers, rule_id, location)
             exit_changed(module, "Rule created", rule_id)
-        exit_ok(module, "Rule already exists")
+        exit_ok(module, "Rule already exists", rule_id)
 
     # Fallback
     exit_failed(module, "Unknown error")


### PR DESCRIPTION
Fix problematic comparisons between the rules described in tasks and the existing rules.

The rule described is created before comparing it, so the module can use the API representation of the rule.

This temporary rule is deleted if an identical rule already exists when creating a rule, and after fetching the ID of the existing rule when deleting a rule.

Notable changes:

The comment and description parameters are omitted from the comparison, because they are not significant. Creating two identical rules with a different description or comment is not possible, and they are also ignored when deleting rules.


## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Correct rule comparison is nearly impossible due to differences between the API representation of the rule and the module's representation, especially for the value_raw.

Issue Number: #186

## What is the new behavior?
Rule comparison uses the API representation on both sides, so it 'always' succeeds.
