### PR TITLE
Fix password for activation

### DIFF
--- a/roles/agent/handlers/main.yml
+++ b/roles/agent/handlers/main.yml
@@ -5,7 +5,7 @@
     server_url: "{{ checkmk_agent_protocol }}://{{ checkmk_agent_server }}"
     site: "{{ checkmk_agent_site }}"
     automation_user: "{{ checkmk_agent_user }}"
-    automation_secret: "{{ checkmk_agent_pass }}"
+    automation_secret: "{{ checkmk_agent_auth }}"
     force_foreign_changes: 'false'
   delegate_to: localhost
   run_once: 'true'


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
In the activation handler for the agent the password variable `checkmk_agent_pass` is used.
In the `vars/main.yml` the credentials are assembled to `checkmk_agent_auth` and this the one that is used in the rest of
the code.

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
The activation of the host breaks the playbook in the handler part, as the variable `checkmk_agent_pass` is undefined.

## What is the new behavior?

The host is activated in the CheckMK server

