### PR TITLE
Use safe_eval instead of temporary rules for comparison

### DIFF
--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -224,8 +224,8 @@ id:
 import json
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.urls import fetch_url
 from ansible.module_utils.common.validation import safe_eval
+from ansible.module_utils.urls import fetch_url
 
 try:
     from urllib import urlencode

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -458,7 +458,6 @@ def run_module():
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
 
-
     # Use the parameters to initialize some common variables
     headers = {
         "Accept": "application/json",
@@ -479,7 +478,6 @@ def run_module():
     ruleset = module.params.get("ruleset", "")
     rule = module.params.get("rule", "")
     location = rule.get("location")
-
 
     # Check if required params to create a rule are given
     if rule.get("folder") is None or rule.get("folder") == "":

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -93,15 +93,6 @@ author:
 notes:
     - "To achieve idempotency, this module is comparing the specified rule with the already existing
       rules based on conditions, folder, value_raw and enabled/disabled."
-    - "To be able to compare the value_raw, which is internally stored in python format, the module
-      has to do a workaround: it is creating the specified rule, and then compares this rule with
-      all existing rules."
-    - "Then, in case of I(state=absent), it will delete both rules: the specified one and the duplicate
-      found."
-    - "Or, in case of I(state=present), it will delete the new rule, if a duplicate is already there,
-      and keep it if not."
-    - "This obviously leads to more rules being added and removed as one might expect. That's also
-      visible in the pending changes and audit log."
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -74,8 +74,10 @@ options:
                 description: Properties of the rule.
                 type: dict
             value_raw:
-                description: Rule values as exported from the UI.
-                type: str
+                description:
+                    - Rule values as exported from the GUI.
+                    - The object exported by the GUI is a string, it will be converted to a dict by ansible's argument parsing.
+                type: dict
     ruleset:
         description: Name of the ruleset to manage.
         required: true
@@ -284,7 +286,7 @@ def get_existing_rule(module, base_url, headers, ruleset, rule):
                 == rule["properties"]["disabled"]
                 and r["extensions"]["folder"] == rule["folder"]
                 and safe_eval(r["extensions"]["value_raw"])
-                == safe_eval(rule["value_raw"])
+                == rule["value_raw"]
             ):
                 # If they are the same, return the ID
                 return r
@@ -421,7 +423,7 @@ def run_module():
                 folder=dict(type="str"),
                 conditions=dict(type="dict"),
                 properties=dict(type="dict"),
-                value_raw=dict(type="str"),
+                value_raw=dict(type="dict"),
                 location=dict(
                     type="dict",
                     options=dict(

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -74,7 +74,7 @@ options:
                 description: Properties of the rule.
                 type: dict
             value_raw:
-                description: Rule values as exported from the GUI.
+                description: Rule values as exported from the web interface.
                 type: str
     ruleset:
         description: Name of the ruleset to manage.

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -275,16 +275,24 @@ def get_existing_rule(module, base_url, headers, ruleset, rule):
     # Get rules in ruleset
     rules = get_rules_in_ruleset(module, base_url, headers, ruleset)
 
+    (value_mod, exc) = safe_eval(rule["value_raw"], include_exceptions=True)
+    if exc is not None:
+        exit_failed(module, "value_raw in rule has invalid format")
+
     if rules is not None:
         # Loop through all rules
         for r in rules.get("value"):
+            (value_api, exc) = safe_eval(
+                r["extensions"]["value_raw"], include_exceptions=True
+            )
+            if exc is not None:
+                exit_failed("Error deserializing value_raw from API")
             if (
-                r["extensions"]["conditions"] == rule["conditions"]
+                r["extensions"]["folder"] == rule["folder"]
+                and r["extensions"]["conditions"] == rule["conditions"]
                 and r["extensions"]["properties"]["disabled"]
                 == rule["properties"]["disabled"]
-                and r["extensions"]["folder"] == rule["folder"]
-                and safe_eval(r["extensions"]["value_raw"])
-                == safe_eval(rule["value_raw"])
+                and value_api == value_mod
             ):
                 # If they are the same, return the ID
                 return r

--- a/tests/integration/targets/rule/vars/main.yml
+++ b/tests/integration/targets/rule/vars/main.yml
@@ -41,3 +41,32 @@ checkmk_rules:
         "documentation_url": "https://github.com/tribe29/ansible-collection-tribe29.checkmk/blob/main/plugins/modules/rules.py"
       }
       value_raw: "{'levels': (80.0, 90.0)}"
+  - ruleset: "periodic_discovery"
+    rule:
+      location:
+          position: "top"
+          folder: "/"
+      properties:
+        comment: "Created by Ansible"
+        description: "Perform Service Discovery every 5 minutes"
+        disabled: false
+      conditions:
+        host_labels:
+          - key: "robotmk"
+            operator: "is"
+            value: "yes"
+      value_raw: "{
+        'check_interval': 5.0,
+        'inventory_rediscovery': {
+          'activation': True,
+          'excluded_time': [],
+          'group_time': 900,
+          'mode': 2,
+          'service_filters':(
+            'combined', {'service_whitelist': ['^E2E.*']}
+          )
+        },
+        'severity_new_host_label': 0,
+        'severity_unmonitored': 0,
+        'severity_vanished': 0
+      }"

--- a/tests/integration/targets/rule/vars/main.yml
+++ b/tests/integration/targets/rule/vars/main.yml
@@ -51,6 +51,8 @@ checkmk_rules:
         description: "Perform Service Discovery every 5 minutes"
         disabled: false
       conditions:
+        host_tags: []
+        service_labels: []
         host_labels:
           - key: "robotmk"
             operator: "is"


### PR DESCRIPTION
In PR #233 we create temporary rules as a means to get the exact API representation for the value_raw.

Ansible's module_utils library provides a "safe_eval()" implementation of ast.literal_eval(). As it was suggested by a developer in #153 we could use this technique to evaluate the values as Python objects before the comparison, as other modules and checkmk api does.

This removes the need to create a temporary rule.

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Create temp rule
Fill the logs
Slow

Issue Number: #153 #186

## What is the new behavior?
Use safe_eval from ansible module_utils
Does not fill the logs
Faster