### PR TITLE
change 'is false' to '== false'

### DIFF
--- a/roles/server/tasks/update-site.yml
+++ b/roles/server/tasks/update-site.yml
@@ -19,7 +19,7 @@
     msg: |
       Downgrading is not allowed since checkmk_server_allow_downgrades is set to false.
   when:
-    checkmk_server_allow_downgrades is defined 
+    checkmk_server_allow_downgrades is defined
     and not checkmk_server_allow_downgrades | bool
     and item.stdout is version(item.item.version, '>')
 

--- a/roles/server/tasks/update-site.yml
+++ b/roles/server/tasks/update-site.yml
@@ -19,7 +19,7 @@
     msg: |
       Downgrading is not allowed since checkmk_server_allow_downgrades is set to false.
   when:
-    checkmk_server_allow_downgrades | bool is false
+    checkmk_server_allow_downgrades | bool == false
     and item.stdout is version(item.item.version, '>')
 
 - name: "Short pause for patch update."

--- a/roles/server/tasks/update-site.yml
+++ b/roles/server/tasks/update-site.yml
@@ -19,7 +19,8 @@
     msg: |
       Downgrading is not allowed since checkmk_server_allow_downgrades is set to false.
   when:
-    checkmk_server_allow_downgrades | bool == false
+    checkmk_server_allow_downgrades is defined 
+    and not checkmk_server_allow_downgrades | bool
     and item.stdout is version(item.item.version, '>')
 
 - name: "Short pause for patch update."


### PR DESCRIPTION
Was getting an error: 
FAILED! => {"msg": "The conditional check 'checkmk_server_allow_downgrades | bool is false\nand item.stdout is version(item.item.version, '>')\n' failed. The error was: template error while templating string: no test named 'false'.  so replaced 'is false' to '== false'

<!--- Please provide a general summary of your changes in the title above -->

<!---
Please use the devel branch as the merge target!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, if people are using the branch directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When trying to upgrade server versions, I see an error:

FAILED! => {"msg": "The conditional check 'checkmk_server_allow_downgrades | bool is false\nand item.stdout is version(item.item.version, '>')\n' failed. The error was: template error while templating string: no test named 'false'. 

## What is the new behavior?

The upgrade now works:

Pausing for 5 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
[tribe29.checkmk.server : Short pause for patch update.]
Proceeding with updating site test from version 2.1.0p17.cre to version 2.1.0p20.cre.
This is a minor patch update. A backup will be created in /tmp. This can take a while! The site will be down during the update

-
-
-

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
