### PR TITLE
Fix rule module for #290

### DIFF
--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -283,8 +283,8 @@ def get_existing_rule(module, base_url, headers, ruleset, rule):
             if (
                 r["extensions"]["folder"] == rule["folder"]
                 and r["extensions"]["conditions"] == rule["conditions"]
-                and r["extensions"]["properties"]["disabled"]
-                == rule["properties"]["disabled"]
+                and r["extensions"]["properties"].get("disabled", "")
+                == rule["properties"].get("disabled", "")
                 and value_api == value_mod
             ):
                 # If they are the same, return the ID


### PR DESCRIPTION
Fix for #290
## Pull request type
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Crash when the API does not return a value for the 'disabled' property

Issue Number: #290

## What is the new behavior?
Set a default value for the disabled property when comparing

